### PR TITLE
Fix module declaration

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -40,6 +40,6 @@ go:
   maxMethodParams: 4
   methodArguments: require-security-and-request
   outputModelSuffix: output
-  packageName: firehydrant
+  packageName: github.com/firehydrant/firehydrant-go-sdk
   responseFormat: flat
   templateVersion: v2

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module firehydrant
+module github.com/firehydrant/firehydrant-go-sdk
 
 go 1.22
 


### PR DESCRIPTION
Updates module declaration for the go sdk to fix:
```
go: github.com/firehydrant/firehydrant-go-sdk@upgrade (v1.1.3) requires github.com/firehydrant/firehydrant-go-sdk@v1.1.3: parsing go.mod:
        module declares its path as: firehydrant
                but was required as: github.com/firehydrant/firehydrant-go-sdk
```

Correctly generating SDK with expected module path
Action: https://github.com/firehydrant/firehydrant-go-sdk/actions/runs/16275911746/job/45954636725
Resulting PR: https://github.com/firehydrant/firehydrant-go-sdk/pull/11/files